### PR TITLE
Don't parse nonsense output

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,0 +1,1 @@
+linters: with_defaults(line_length_linter(100), commented_code_linter = NULL, open_curly_linter = NULL, closed_curly_linter = NULL, object_length_linter = NULL, multiple_dots_linter = NULL)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: num
 Title: Specify large numbers in R using human language
-Version: 0.0.0.9000
+Version: 0.0.1
 Authors@R: person("Peter", "Hurford", email = "peter@peterhurford.com", role = c("aut", "cre"))
 Description: See https://github.com/peterhurford/num/blob/master/README.md
 Depends:

--- a/R/num.R
+++ b/R/num.R
@@ -20,6 +20,7 @@ num <- checkr::ensure(
     for (i in seq_along(abbrev)) {
       if (grepl(names(abbrev)[[i]], num)) {
         num <- gsub(names(abbrev)[[i]], paste("*", abbrev[[i]]), num)
+        break
       }
     }
     tryCatch({

--- a/tests/testthat/test-num.R
+++ b/tests/testthat/test-num.R
@@ -44,6 +44,11 @@ describe("letter interpolation is parsable", {
   }
 })
 
+test_that("multiple letter interpolation is not parsable", {
+  expect_error(num::num("40M2K"))
+  expect_error(num::num("40M20K"))
+})
+
 describe("decimal separation is parsable with letters", {
   random_nums <- round(runif(100, 1, 100000), 3)
   for (i in seq_along(abbrev)) {


### PR DESCRIPTION
Resolves https://github.com/peterhurford/num/issues/2 by only allowing one letter to be parsed per num expression. This means that `40MK` will no longer work, but I don't think people were really planning on using num for that.
